### PR TITLE
Fix search bug.

### DIFF
--- a/ripple/src/main/webapp/accountsettings.html
+++ b/ripple/src/main/webapp/accountsettings.html
@@ -47,7 +47,7 @@
               <!-- Search box -->
               <div class="search">
                 <i class="material-icons">search</i>
-                <input class="search-bar" id="search-bar" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
+                <input class="search-bar" id="search-bar" onkeyup="searchInput(event)" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
                 <datalist id="search-autocomplete"></datalist>
               </div>
               <!-- ./Search box -->

--- a/ripple/src/main/webapp/businessdetails.html
+++ b/ripple/src/main/webapp/businessdetails.html
@@ -49,7 +49,7 @@
               <!-- Search box -->
               <div class="search">
                 <i class="material-icons">search</i>
-                <input class="search-bar" id="search-bar" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
+                <input class="search-bar" id="search-bar" onkeyup="searchInput(event)" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
                 <datalist id="search-autocomplete"></datalist>
               </div>
               <!-- ./Search box -->

--- a/ripple/src/main/webapp/businessgallery.html
+++ b/ripple/src/main/webapp/businessgallery.html
@@ -54,7 +54,7 @@
               <!-- Search box -->
               <div class="search">
                 <i class="material-icons">search</i>
-                <input class="search-bar" id="search-bar" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
+                <input class="search-bar" id="search-bar" onkeyup="searchInput(event)" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
                 <datalist id="search-autocomplete"></datalist>
               </div>
               <!-- ./Search box -->

--- a/ripple/src/main/webapp/main.html
+++ b/ripple/src/main/webapp/main.html
@@ -48,7 +48,7 @@
               <!-- Search box -->
               <div class="search">
                 <i class="material-icons">search</i>
-                <input class="search-bar primary-bg-color" id="search-bar" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
+                <input class="search-bar primary-bg-color" id="search-bar" onkeyup="searchInput(event)" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
                 <datalist id="search-autocomplete"></datalist>
               </div>
               <!-- ./Search box -->

--- a/ripple/src/main/webapp/managebusiness.html
+++ b/ripple/src/main/webapp/managebusiness.html
@@ -44,7 +44,7 @@
               <!-- Search box -->
               <div class="search">
                 <i class="material-icons">search</i>
-                <input class="search-bar" id="search-bar" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
+                <input class="search-bar" id="search-bar" onkeyup="searchInput(event)" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
                 <datalist id="search-autocomplete"></datalist>
               </div>
               <!-- ./Search box -->

--- a/ripple/src/main/webapp/posts.html
+++ b/ripple/src/main/webapp/posts.html
@@ -46,8 +46,7 @@
               <!-- Search box -->
               <div class="search">
                 <i class="material-icons">search</i>
-                <input class="search-bar primary-bg-color" id="search-bar" list="search-autocomplete" type="text" 
-                     placeholder="Search for anything..." autocomplete="off">
+                <input class="search-bar primary-bg-color" id="search-bar" onkeyup="searchInput(event)" list="search-autocomplete" type="text" placeholder="Search for anything..." autocomplete="off">
                 <datalist id="search-autocomplete"></datalist>
               </div>
               <!-- ./Search box -->

--- a/ripple/src/main/webapp/posts.js
+++ b/ripple/src/main/webapp/posts.js
@@ -52,8 +52,6 @@ function postsOnload() {
   }
 }
 
-
-
 /* Add data to Firestore without doc id*/
 function newPost() {
   // Remove caption from local storage

--- a/ripple/src/main/webapp/script.js
+++ b/ripple/src/main/webapp/script.js
@@ -207,17 +207,19 @@ function viewAllPostComments() {
 
 /* Backend for search functionality */
 
-var searchString = document.getElementById("search-bar");
-searchString.addEventListener('keyup', searchInput);
-
-// /* Takes navbar search input, stores in session storage. */
-function searchInput(keyPress) {
+/* Takes navbar search input, stores in local storage. */
+function searchInput(event) {
   console.log("searchInput() called");
   var searchString = document.getElementById("search-bar").value;
-  console.log(searchString)
-  if (keyPress.keyCode != ENTER_KEY) {
+  console.log(searchString);
+  // If there was a key press but the input is empty, return
+  if (!searchString) { 
+    return false;
+  }
+  // If any key other than enter is pressed, autocomplete word
+  if (event.keyCode != ENTER_KEY) {
     autocompleteSearch(searchString);
-  } else {
+  } else { // If enter is pressed, save user's input and redirect page
     console.log(searchString);
     localStorage.setItem("galleryPageSearchTag", searchString);
     localStorage.setItem("galleryPageName", "'" + searchString + "'");


### PR DESCRIPTION
**Issue**: JS 'keyup' event listener was previously applied onto the general 'document' instead of the search bar input, causing every page with an input or textarea to redirect to the businessgallery page if the user presses enter. The first fix also failed to produce the desired behavior: When the event listener was dynamically added to the search bar instead, no keyup events registered at all. 

**Solution**: Add the 'onkeyup' function directly in the HTML. Pass in an 'event' oarameter so that the key code can later be read.