### PR TITLE
Redesigns image gallery layout on business details page

### DIFF
--- a/ripple/src/main/webapp/businessdetails.html
+++ b/ripple/src/main/webapp/businessdetails.html
@@ -69,7 +69,7 @@
       </div>
       <!-- /.Navbar -->
       <!-- Business details image gallery TODO: SMRUTHI DYNAMICALLY ALLOCATE EXISTING IMGS FROM BD EDIT PAGE AS A CAROUSEL -->
-      <div class="container bd-gallery"> 
+      <div class="bd-gallery"> 
           <div id="imageGallery" class="carousel slide" data-interval="false">
             <div class="carousel-inner row w-100 mx-auto" id="firstRow"></div>
             <a class="carousel-control-prev" href="#imageGallery" role="button" data-slide="prev">

--- a/ripple/src/main/webapp/businessdetails.js
+++ b/ripple/src/main/webapp/businessdetails.js
@@ -63,6 +63,7 @@ function bdOnload() {
   // Access 'businessDetails' collection
   var lambda = (doc) => {
         if (doc.exists) {
+          // Read and iterate over blobKeys, add the images to carousel.
           var i;
           for (i = 0; i < doc.data().galleryBlobKeys.length; i++) {
             console.log(doc.data().galleryBlobKeys[i]);
@@ -142,6 +143,17 @@ function bdOnload() {
         }
       }
   getDocByDocId("businessDetails", businessId, lambda);
+
+  var lambda2 = (doc) => {
+        if (doc.exists) {
+          var j;
+          for (j = 0; j < 4; j++) {
+            console.log("tags: " + Object.keys(doc.data().tags).toString());
+            //createCarouselElement(doc.data().galleryBlobKeys[i], "imageGallery");
+          }
+        }
+  }
+  getDocByDocId("businesses", businessId, lambda2);
 }
 
 /* Address (Quick Info section): Display street addres */

--- a/ripple/src/main/webapp/script.js
+++ b/ripple/src/main/webapp/script.js
@@ -362,7 +362,7 @@ function createCarouselElement(blobKey, id) {
     var content = `
         <div class="carousel-item col-md-4">
         <div class="card">
-            <img class="card-img-top img-fluid" id="card-dynamic-image" src="/serve?blob-key=${blobKey}"></img>
+          <img class="card-img-top img-fluid" id="card-dynamic-image" src="/serve?blob-key=${blobKey}"></img>
         </div>
         </div>
     `;

--- a/ripple/src/main/webapp/style.css
+++ b/ripple/src/main/webapp/style.css
@@ -467,8 +467,8 @@
   width: 100%;
   height: 13vw;
   object-fit: cover;
-  max-height: 200px;
-  min-height: 175px;
+  max-height: 250px;
+  min-height: 225px;
 }
 
 .card-text {
@@ -863,8 +863,11 @@
 }
 
 #imageGallery {
-  padding-left: -30px;
   justify-content: center;
+  width: calc(100% - 40px);
+  vertical-align: middle;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .star-color {

--- a/ripple/src/main/webapp/style.css
+++ b/ripple/src/main/webapp/style.css
@@ -465,8 +465,10 @@
 
 .card-img-top {
   width: 100%;
-  height: 12vw;
+  height: 13vw;
   object-fit: cover;
+  max-height: 200px;
+  min-height: 175px;
 }
 
 .card-text {
@@ -850,12 +852,16 @@
 
 /* Business details page */
 .three-quarters-bg-no-color {
-  height: 400px;
-  border-bottom: solid var(--neutral-light-color) 1px;
+  height: 350px;
 }
 
 .bd-gallery {
-  height: 345px;
+  max-height: 350px;
+}
+
+#imageGallery {
+  padding-left: -30px;
+  justify-content: center;
 }
 
 .star-color {
@@ -874,7 +880,7 @@
 }
 
 .bd-padding-top {
-  padding-top: 30px;
+  padding-top: 20px;
 }
 
 .bd-padding-top-lg {


### PR DESCRIPTION
**Description:** Fixes image carousel resizing issues with page resize. Redesigns header to remove the line underneath gallery. Adds a min and max height to card image to avoid overlapping images and text and minimize white space. Makes carousel a banner across page.

**Demo:**
![image_gall_resize](https://user-images.githubusercontent.com/20546276/89367556-36b8c400-d68e-11ea-81cc-1a42d7741dad.gif)
