### PR TITLE
Adds tags to the business details page dynamically

### DIFF
--- a/ripple/src/main/webapp/businessdetails.html
+++ b/ripple/src/main/webapp/businessdetails.html
@@ -99,22 +99,10 @@
         <p class="inline-block-child" id="bd-phone-number"></p>
         <div class="inline-block-child"><div class="vl"></div></div>
         <a class="inline-block-child hyper-link" id="business-website"></a>
-        <div class="d-flex flex-row flex-wrap justify-content-left">
-		    <button type="button" id="Indian" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Indian')"> Indian </button>
-            <button type="button" id="Chinese" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Chinese')"> Chinese </button>
-            <button type="button" id="Thai" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Thai')"> Thai </button>
-            <button type="button" id="Italian" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Italian')"> Italian </button>
-            <button type="button" id="Middle eastern" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Middle eastern')"> Middle eastern </button>
-		    <button type="button" id="Mediterranean" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Mediterranean')"> Mediterranean </button>
-            <button type="button" id="Mexican" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Mexican')"> Mexican </button>
-            <button type="button" id="Asian" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Asian')"> Asian </button>
-            <button type="button" id="American" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('American')"> American </button>
-	    </div>
+        <!-- tags -->
+        <div id="business-tags-header" class="d-flex flex-row flex-wrap justify-content-left"></div>
+        <!-- ./tags -->
       </div>
-      <!-- tags TODO: SMRUTHI CREATE + DYNAMICALLY LOAD TAGS -->
-      <div class="bd-tags">
-      </div>
-      <!-- ./tags -->
       <h1 class="bd-header" id="bd-header"></h1>
       <!-- Ratings & price-->
       <div>

--- a/ripple/src/main/webapp/businessdetails.html
+++ b/ripple/src/main/webapp/businessdetails.html
@@ -99,6 +99,17 @@
         <p class="inline-block-child" id="bd-phone-number"></p>
         <div class="inline-block-child"><div class="vl"></div></div>
         <a class="inline-block-child hyper-link" id="business-website"></a>
+        <div class="d-flex flex-row flex-wrap justify-content-left">
+		    <button type="button" id="Indian" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Indian')"> Indian </button>
+            <button type="button" id="Chinese" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Chinese')"> Chinese </button>
+            <button type="button" id="Thai" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Thai')"> Thai </button>
+            <button type="button" id="Italian" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Italian')"> Italian </button>
+            <button type="button" id="Middle eastern" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Middle eastern')"> Middle eastern </button>
+		    <button type="button" id="Mediterranean" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Mediterranean')"> Mediterranean </button>
+            <button type="button" id="Mexican" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Mexican')"> Mexican </button>
+            <button type="button" id="Asian" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('Asian')"> Asian </button>
+            <button type="button" id="American" class="secondary-fill-chip bd-subheader-padding-top inline-block-child" onclick="clickTag('American')"> American </button>
+	    </div>
       </div>
       <!-- tags TODO: SMRUTHI CREATE + DYNAMICALLY LOAD TAGS -->
       <div class="bd-tags">

--- a/ripple/src/main/webapp/businessdetails.js
+++ b/ripple/src/main/webapp/businessdetails.js
@@ -202,7 +202,7 @@ function bdOnload() {
         if (doc.exists) {
           var j;
           for (j = 0; j < 4; j++) {
-            console.log("tags: " + Object.keys(doc.data().tags).toString());
+            //console.log("tags: " + Object.keys(doc.data().tags).toString());
             //createCarouselElement(doc.data().galleryBlobKeys[i], "imageGallery");
           }
         }

--- a/ripple/src/main/webapp/businessdetails.js
+++ b/ripple/src/main/webapp/businessdetails.js
@@ -71,8 +71,6 @@ function displaySavedRatings() {
   }
 }
 
-/* [SMRUTHI TODO] Serve blob images in a gallery */
-
 /* [SMRUTHI TODO] Add business tags above restaurant header */
 
 /* [SARAH / SMRUTHI TODO] Add a review: Anonymous user that attempts to post is redirect to login, then redirected back. 
@@ -368,17 +366,29 @@ function bdOnload() {
         }
       }
   getDocByDocId("businessDetails", businessId, lambda);
-
-  var lambda2 = (doc) => {
+  
+  /* Function to iterate over all the tags for a business and add them to the business details page */
+  var queryTags = (doc) => {
         if (doc.exists) {
+          var tagsMap = doc.data().tags;
+          var tagsList = Object.keys(tagsMap);
           var j;
-          for (j = 0; j < 4; j++) {
-            //console.log("tags: " + Object.keys(doc.data().tags).toString());
-            //createCarouselElement(doc.data().galleryBlobKeys[i], "imageGallery");
+          for (j = 0; j < tagsList.length; j++) {
+            var tag = tagsList[j];
+            //console.log(tag);
+            createTagElement(tagsMap[tag]);
           }
         }
   }
-  getDocByDocId("businesses", businessId, lambda2);
+  getDocByDocId("businesses", businessId, queryTags);
+}
+
+/* Function that dynamically creates tag elements */
+function createTagElement(tagId) {
+  var tagsDiv = document.getElementById('business-tags-header');
+  var content = 
+  ` <button type="button" class="no-fill-chip bd-subheader-padding-top inline-block-child">${tagId}</button> `;
+  tagsDiv.innerHTML = tagsDiv.innerHTML + content + "\n"; 
 }
 
 /* Address (Quick Info section): Display street addres */

--- a/ripple/src/main/webapp/style.css
+++ b/ripple/src/main/webapp/style.css
@@ -469,6 +469,7 @@
   object-fit: cover;
   max-height: 250px;
   min-height: 225px;
+  cursor: pointer;
 }
 
 .card-text {
@@ -1204,6 +1205,30 @@
 
 .visibility-hidden {
   visibility: hidden;
+}
+
+.no-fill-chip {
+  background-color: transparent;
+  border: 1px solid var(--neutral-color);
+  border-radius: 30px;
+  color: var(--neutral-color);
+  cursor: pointer;
+  font-size: 20px;
+  font-weight: var(--normal-font-weight);
+  height: 50px;
+  outline: none;
+  padding: 5px 40px 0px 40px;
+  margin-left: 10px;
+}
+
+.no-fill-chip:hover {
+  cursor: default;
+}
+
+.no-fill-chip:focus, .no-fill-chip:active {
+  outline: none;
+  cursor: default;
+  border-color: var(--neutral-light-color);
 }
 
 /* Manage business info */


### PR DESCRIPTION
**Description:** Adds tags to the business details page by querying Firestore and dynamically adding tag elements to the page. Restyled tag to appear more flat, like a chip rather than a button. Have completed all the business details page features that I independently own (image gallery and tags).

**Image:**
![Screenshot 2020-08-05 at 2 02 05 AM](https://user-images.githubusercontent.com/20546276/89394102-80ba9d80-d6c0-11ea-80bc-eb40cd86f869.png)
